### PR TITLE
[hotfix] admin token의 주소를 properties 파일로 옮김에 따라 발생한 '찾을 수 없음'문제 해결

### DIFF
--- a/src/main/java/com/example/itwassummer/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/itwassummer/user/service/UserServiceImpl.java
@@ -22,7 +22,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Value("${admin.token}")
-    private static String adminToken;
+    private String adminToken;
 
     @Transactional
     @Override


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* #13

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* 기존 코드에서 adminToken을 properties 파일로 옮김에 따라 해당 값을 `찾을 수 없음` 문제가 발생하여 static을 제거함

## 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요 -->  

* 기입 예 - 1. ~~ 발생한 예외 이름 또는 뭐 하다가 예외 발생했다. 기록

발생한 문제

```java
 adminToken 값이 null 인 것을 발견
```

예외가 발생한 코드

```java
// UserServiceImpl.java
@Value("${admin.token}")
private static String adminToken;
```

원인 분석

> static 변수에 대해선 @Value 어노테이션이 동작하지 않는다. 
> <br> (참고 링크: https://jkpark.me/springboot/java/2020/06/04/Spring-Boot-static-%EB%B3%80%EC%88%98%EC%97%90%EC%84%9C-@value-annontation-%EC%82%AC%EC%9A%A9.html)

수정한 코드

```java
// UserServiceImpl.java
@Value("${admin.token}")
private String adminToken;
```