### PR TITLE
[init] 카드 엔티티 구현 (다른 테이블과 관계는 추후에 구현)

### DIFF
--- a/src/main/java/com/example/itwassummer/card/controller/CardController.java
+++ b/src/main/java/com/example/itwassummer/card/controller/CardController.java
@@ -1,0 +1,77 @@
+package com.example.itwassummer.card.controller;
+
+
+import com.example.itwassummer.card.dto.CardRequestDto;
+import com.example.itwassummer.card.dto.CardResponseDto;
+import com.example.itwassummer.card.entity.Card;
+import com.example.itwassummer.card.service.CardService;
+import com.example.itwassummer.common.dto.ApiResponseDto;
+import com.example.itwassummer.common.security.UserDetailsImpl;
+import com.example.itwassummer.user.dto.SignupRequestDto;
+import com.example.itwassummer.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cards")
+@Tag(name = "카드 API", description = "카드 기능과 관련된 API 정보를 담고 있습니다.")
+public class CardController {
+
+  public CardController (CardService cardService) {
+    this.cardService = cardService;
+  }
+  private final CardService cardService;
+
+  @Operation(summary = "카드 등록", description = "CardRequestDto를 통해 카드정보를 전달 받은 후 DB에 저장하고 성공 메시지를 반환합니다.")
+  @PostMapping("/")
+  public ResponseEntity addCards(@Valid @RequestBody CardRequestDto requestDto) throws IllegalAccessException {
+    CardResponseDto returnDto = cardService.save(requestDto);
+    return new ResponseEntity<>(returnDto, HttpStatus.OK);
+  }
+
+  @Operation(summary = "카드 수정", description = "CardRequestDto를 통해 카드정보를 전달 받은 후 DB에 저장하고 성공 메시지를 반환합니다.")
+  @PutMapping("/")
+  public ResponseEntity updateCards(@Valid @RequestBody CardRequestDto requestDto) throws IllegalAccessException {
+    CardResponseDto returnDto = cardService.update(requestDto);
+    return new ResponseEntity<>(returnDto, HttpStatus.OK);
+  }
+
+  @Operation(summary = "카드 삭제", description = "id 값을 통해 삭제")
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponseDto> deleteCards(@PathVariable("id") Long id) throws IllegalAccessException {
+    cardService.delete(id);
+    return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "회원 가입 성공"));
+  }
+
+
+  /**
+   * 댓글 목록 조회
+   * */
+  @GetMapping("/{cardId}/comments")
+  @ResponseBody
+  public ResponseEntity list(
+      @RequestParam("page") int page,
+      @RequestParam("size") int size,
+      @RequestParam("sortBy") String sortBy,
+      @RequestParam("isAsc") boolean isAsc
+  ) {
+    return null;
+  }
+
+
+}

--- a/src/main/java/com/example/itwassummer/card/dto/CardRequestDto.java
+++ b/src/main/java/com/example/itwassummer/card/dto/CardRequestDto.java
@@ -1,0 +1,36 @@
+package com.example.itwassummer.card.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardRequestDto {
+
+
+  // 카드 이름
+  @NotBlank
+  private String name;
+
+  // 만기일
+  @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime dueDate;
+
+  // 설명
+  private String description;
+
+  // 정렬순서
+  private Long parentId;
+
+
+
+
+}

--- a/src/main/java/com/example/itwassummer/card/dto/CardResponseDto.java
+++ b/src/main/java/com/example/itwassummer/card/dto/CardResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.itwassummer.card.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardResponseDto {
+
+  // 카드 이름
+  private String name;
+
+  // 만기일
+  private String dueDate;
+
+  // 설명
+  private String description;
+
+  // 정렬순서
+  private Long parentId;
+
+}

--- a/src/main/java/com/example/itwassummer/card/entity/Card.java
+++ b/src/main/java/com/example/itwassummer/card/entity/Card.java
@@ -1,6 +1,10 @@
 package com.example.itwassummer.card.entity;
 
+import com.example.itwassummer.card.dto.CardRequestDto;
+import com.example.itwassummer.deck.entity.Deck;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,5 +17,44 @@ public class Card {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "card_id")
     private Long id;
+
+    @Column(length = 10, nullable = false)
+    private String name;
+
+    @Column
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime dueDate;
+
+
+    @Column(length = 100)
+    private String description;
+
+   /*
+   @ManyToOne
+    @JoinColumn(name = "deck_id")
+    private Deck deck;
+
+    Deck 엔티티에 추가
+    @OneToMany(mappedBy = "deck", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Card> cards = new ArrayList<>();
+
+    */
+
+    @Column(length = 10, nullable = false)
+    private Long parentId;
+
+    @Builder
+    public Card(String name, LocalDateTime dueDate, String description, Long parentId){
+        this.name = name;
+        this.dueDate = dueDate;
+        this.description = description;
+        this.parentId = parentId;
+    }
+
+    public void update(CardRequestDto requestDto) {
+        this.name = requestDto.getName();
+        this.dueDate = requestDto.getDueDate();
+        this.description = requestDto.getDescription();
+    }
 
 }

--- a/src/main/java/com/example/itwassummer/card/repository/CardRepository.java
+++ b/src/main/java/com/example/itwassummer/card/repository/CardRepository.java
@@ -1,0 +1,8 @@
+package com.example.itwassummer.card.repository;
+
+import com.example.itwassummer.card.entity.Card;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardRepository  extends JpaRepository<Card, Long> {
+
+}

--- a/src/main/java/com/example/itwassummer/card/service/CardService.java
+++ b/src/main/java/com/example/itwassummer/card/service/CardService.java
@@ -1,0 +1,32 @@
+package com.example.itwassummer.card.service;
+
+import com.example.itwassummer.card.dto.CardRequestDto;
+import com.example.itwassummer.card.dto.CardResponseDto;
+import com.example.itwassummer.card.repository.CardRepository;
+import com.example.itwassummer.user.dto.SignupRequestDto;
+import com.example.itwassummer.user.repository.UserRepository;
+
+public interface CardService {
+
+  /**
+   * 카드 등록
+   * @param requestDto 카드 등록 요청 정보
+   * @return
+   */
+  CardResponseDto save(CardRequestDto requestDto) throws IllegalAccessException;
+
+
+  /**
+   * 카드 수정
+   * @param requestDto 카드 등록 요청 정보
+   * @return
+   */
+  CardResponseDto update(CardRequestDto requestDto);
+
+  /**
+   * 카드 삭제
+   * @param id 카드 등록 요청 정보
+   * @return
+   */
+  void delete(Long id);
+}

--- a/src/main/java/com/example/itwassummer/card/service/CardServiceImpl.java
+++ b/src/main/java/com/example/itwassummer/card/service/CardServiceImpl.java
@@ -1,0 +1,49 @@
+package com.example.itwassummer.card.service;
+
+import com.example.itwassummer.card.dto.CardRequestDto;
+import com.example.itwassummer.card.dto.CardResponseDto;
+import com.example.itwassummer.card.entity.Card;
+import com.example.itwassummer.card.repository.CardRepository;
+import com.example.itwassummer.common.error.CustomErrorCode;
+import com.example.itwassummer.common.exception.CustomException;
+import com.example.itwassummer.user.dto.SignupRequestDto;
+import com.example.itwassummer.user.entity.User;
+import com.example.itwassummer.user.entity.UserRoleEnum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CardServiceImpl implements CardService{
+
+  private final CardRepository cardRepository;
+
+  @Override
+  public CardResponseDto save(CardRequestDto requestDto) throws IllegalAccessException {
+    Card card = Card.builder()
+        .name(requestDto.getName())
+        .description(requestDto.getDescription())
+        .dueDate(requestDto.getDueDate())
+        .parentId(requestDto.getParentId())
+        .build();
+    Card returnCard = cardRepository.save(card);
+    CardResponseDto responseDto = CardResponseDto
+        .builder()
+        .name(returnCard.getName())
+        .dueDate(String.valueOf(returnCard.getDueDate()))
+        .description(returnCard.getDescription())
+        .build();
+    return responseDto;
+  }
+
+  @Override
+  public CardResponseDto update(CardRequestDto requestDto) {
+    return null;
+  }
+
+  @Override
+  public void delete(Long id) {
+
+  }
+}

--- a/src/test/java/com/example/itwassummer/card/controller/CardControllerTest.java
+++ b/src/test/java/com/example/itwassummer/card/controller/CardControllerTest.java
@@ -1,0 +1,91 @@
+package com.example.itwassummer.card.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.itwassummer.card.dto.CardRequestDto;
+import com.example.itwassummer.user.dto.LoginRequestDto;
+import com.example.itwassummer.user.dto.SignupRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CardControllerTest {
+  @Autowired
+  ObjectMapper mapper;
+
+  @Autowired
+  MockMvc mvc;
+
+  private static final String BASE_URL = "/api/cards";
+  private static final String USER_BASE_URL = "/api/users";
+
+  @Test
+  @DisplayName("카드 등록 테스트")
+  void insert() throws Exception {
+    // given
+    String name = "예시카드1";
+    Long parentId = Long.valueOf(1);
+    String description = "예시카드입니다.";
+    String header = login();
+    LocalDateTime now = LocalDateTime.now();
+
+    // when
+    String body = mapper.writeValueAsString(
+        CardRequestDto.builder()
+            .name(name)
+            .dueDate(now)
+            .parentId(parentId)
+            .description(description)
+            .build()
+    );
+
+    // then
+    mvc.perform(post(BASE_URL + "/")
+            .content(body)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Authorization",header)
+        )
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+
+  String login() throws Exception {
+    // given
+    String email = "user@email.com";
+    String password = "user123!@#";
+
+    // when
+    LoginRequestDto requestDto = new LoginRequestDto();
+    requestDto.setEmail(email);
+    requestDto.setPassword(password);
+
+    String body = mapper.writeValueAsString(requestDto);
+
+    // then
+    MvcResult result = mvc.perform(post(USER_BASE_URL + "/login")
+            .content(body)
+            .contentType(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andDo(print())
+        .andReturn();
+
+    return Objects.requireNonNull(result.getResponse().getHeader("Authorization")).toString();
+  }
+
+}


### PR DESCRIPTION
- 컨트롤러 테스트 코드를 통해 카드 데이터 등록 가능
- 수정 삭제 메소드 작업 중
-  협업을 원활하게 하기 위해 카드 엔티티 사전 커밋하는 것이 목적

## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* 이슈 번호를 기재해주세요 (기입 예:#3)
#12 
## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

* 카드 엔티티 생성(연관되는테이블과 관계는 추후에 작업 진행)
* 테스트 코드를 통해 카드 데이터 등록 완료 
* 카드 수정 삭제 기능 구현 중 

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  

* 기입 예: 예외 처리를 추가적으로 해줘야 합니다.
* 기입 예: 아직 포스트맨 테스트를 해보지 않았습니다.

## Check List

- [ ] 포스트맨으로 체크해 보았나요? 네
- [ ] 테스트 코드를 작성하셨나요? 네


## 트러블 슈팅

<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요 -->  

* 기입 예 - 1. ~~ 발생한 예외 이름 또는 뭐 하다가 예외 발생했다. 기록

발생한 예외

테스트 코드를 진행하기 위해 
 작업한  테스트 메소드 내에서 로그인 처리도 함께 진행한 후 
   본래의 기능(카드 등록) 기능을 수행할 수 있다는 것을 다시 생각해 보게 되었다. 
