### PR TITLE
[hotfix] build Test 안되는 오류 수정

### DIFF
--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -39,7 +39,6 @@ jobs:
 
       # build Test
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
         run: ./gradlew clean build --exclude-task test # 테스트 코드 없을때
 
       # PR conversation & Action에 몇 개의 테스트 중에 몇 개가 통과 되었는지


### PR DESCRIPTION
## 관련 Issue

* #30

## 변경 사항

* build Test 안되는 오류 수정

```java
uses: ~
run: ./gradlew clean build --exclude-task test
```

uses: 와 run: 이 충돌하여 난 문제 uses: 삭제하여 해결

```java
run: ./gradlew clean build --exclude-task test
```
