### PR TITLE
[refactor] aws 파일첨부 기능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
     // AWS
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    
+    //엔티티에 json 선언하기 위한 hibernate 라이브러리
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.3.2'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/example/itwassummer/card/dto/CardRequestDto.java
+++ b/src/main/java/com/example/itwassummer/card/dto/CardRequestDto.java
@@ -1,7 +1,9 @@
 package com.example.itwassummer.card.dto;
 
+import com.example.itwassummer.common.file.S3FileDto;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +33,6 @@ public class CardRequestDto {
 
   // 첨부파일
   @Setter
-  private String attachment;
+  private List<S3FileDto> attachment;
 
 }

--- a/src/main/java/com/example/itwassummer/card/dto/CardResponseDto.java
+++ b/src/main/java/com/example/itwassummer/card/dto/CardResponseDto.java
@@ -25,10 +25,7 @@ public class CardResponseDto {
   // 정렬순서
   private Long parentId;
 
-  // 첨부파일
-  private String attachment;
-
   //첨부파일 정보 표시하는 리스트
-  private List<S3FileDto> attachInfoList = null;
+  private List<S3FileDto> attachment = null;
 
 }

--- a/src/main/java/com/example/itwassummer/card/entity/Card.java
+++ b/src/main/java/com/example/itwassummer/card/entity/Card.java
@@ -5,6 +5,7 @@ import com.example.itwassummer.cardlabel.entity.CardLabel;
 import com.example.itwassummer.comment.entity.Comment;
 import com.example.itwassummer.common.file.S3FileDto;
 import com.example.itwassummer.deck.entity.Deck;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.hibernate.annotations.Type;
 
 @Entity
 @Getter
@@ -38,9 +40,14 @@ public class Card {
 
   @Column(nullable = false)
   private Long parentId;
-
+/*
   @Column
-  private String attachment;
+  private String attachment;*/
+
+  @Convert(converter = S3FileDto.S3FileDtoConverter.class)
+  @Type(JsonType.class)
+  @Column(name="attachment",columnDefinition = "json")
+  private List<S3FileDto> attachment;
 
   //// 연관관계
   @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/example/itwassummer/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/itwassummer/common/exception/GlobalControllerAdvice.java
@@ -2,6 +2,7 @@ package com.example.itwassummer.common.exception;
 
 import com.example.itwassummer.common.dto.ApiResponseDto;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -35,4 +36,11 @@ public class GlobalControllerAdvice {
         ApiResponseDto restApiException = new ApiResponseDto(HttpStatus.NOT_FOUND.value(), ex.getMessage());
          return ResponseEntity.badRequest().body(restApiException);
     }
+
+    @ExceptionHandler({SizeLimitExceededException.class})
+    public ResponseEntity<ApiResponseDto> sizeLimitExceededException(SizeLimitExceededException ex) {
+        ApiResponseDto restApiException = new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        return ResponseEntity.badRequest().body(restApiException);
+    }
+
 }

--- a/src/main/java/com/example/itwassummer/common/file/S3FileDto.java
+++ b/src/main/java/com/example/itwassummer/common/file/S3FileDto.java
@@ -1,6 +1,7 @@
 package com.example.itwassummer.common.file;
 
 
+import com.example.itwassummer.common.util.JsonConverter;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,4 +19,5 @@ public class S3FileDto {
   private String uploadFilePath;
   private String uploadFileUrl;
 
+  public static class S3FileDtoConverter extends JsonConverter<S3FileDto> {}
 }

--- a/src/main/java/com/example/itwassummer/common/util/JsonConverter.java
+++ b/src/main/java/com/example/itwassummer/common/util/JsonConverter.java
@@ -1,0 +1,44 @@
+package com.example.itwassummer.common.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.core.GenericTypeResolver;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+@Converter
+public class JsonConverter<T> implements AttributeConverter<T, String> { // 1
+
+  protected final ObjectMapper objectMapper;
+
+  public JsonConverter() {
+    objectMapper = new ObjectMapper(); // 2
+  }
+
+  @Override
+  public String convertToDatabaseColumn(T attribute) {
+    if (ObjectUtils.isEmpty(attribute)) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(attribute); // 3
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public T convertToEntityAttribute(String dbData) {
+    if (StringUtils.hasText(dbData)) {
+      Class<?> aClass =
+          GenericTypeResolver.resolveTypeArgument(getClass(), JsonConverter.class); // 4
+      try {
+        return (T) objectMapper.readValue(dbData, aClass); // 5
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION

## 관련 Issue

- build.gradle에서 엔티티 컬럼을 json타입으로 지정할 수 있도록 hibernate라이브러리 추가
- 삭제 전에 s3에 남아있는 파일 삭제하도록 처리
- 수정 할때 기존 첨부파일 삭제하는 소스코드 리팩토링
- 파일 첨부용량 초과 시 공통 예외처리 클래스에서 예외처리


#38

## 변경 사항

- 파일 등록 정보를 json 형태로 db 컬럼에 저장 되도록 로직 개선
- 해당 로직을 개선하여 기존 파일 삭제하는 로직을 단순하게 개선
- build.gradle 수정 (라이브러리 추가)
- 예외처리 공통 클래스 케이스 추가(파일용량 초과 시) 

## Todo List

시간 될때 mock 으로 파일첨부 테스트도 해보면 좋을 것 같다. 

## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?

## 트러블 슈팅


- 파일 확장자나 파일 첨부 개수는 프론트에서 진행해도 될 것 같다. 
- 파일 객체를 어떻게 db에 저장할 지에 대해 고민이 많았다. 

처음에는 파일url|파일url|...|파일url 이런 식으로 db에 문자열을 저장 후 
url 에 있는 파일경로와 파일명을 읽어 파일 삭제기능을 구현하였다. 

그러나, 일일이 split 인덱스를 지정 해줘야하는 문제, 실수를 할 가능성
코드량이 길어지는 문제가 발생하였다.

-> 

AttributeConverter 클래스,  
hypersistence-utils 라이브러리(엔티티의 컬럼에 json 타입을 용이하게 지정하도록 도와줌)
를 적용하여 
해결